### PR TITLE
Update fetchRevisions to use the complete prefix

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -114,11 +114,12 @@ module.exports = CoreObject.extend({
     var bucket         = options.bucket;
     var prefix         = options.prefix;
     var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":");
+    var fullPrefix     = joinUriSegments(prefix, options.filePattern + ":" + options.revisionKey);
     var indexKey       = joinUriSegments(prefix, options.filePattern);
     var listObjects    = Promise.denodeify(client.listObjects.bind(client));
 
     return Promise.hash({
-      revisions: listObjects({ Bucket: bucket, Prefix: revisionPrefix }),
+      revisions: listObjects({ Bucket: bucket, Prefix: fullPrefix }),
       current: headObject(client, { Bucket: bucket, Key: indexKey }),
     })
     .then(function(data) {


### PR DESCRIPTION
## What Changed & Why
- Updated `s3.fetchRevisions` to use a full prefix when fetching s3 objects; this is an issue when the existing partial prefix matches >1000 objects (the s3 api only returns the first 1000)
## Related issues

Link to related issues in this or other repositories (if any)
## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]
## People

Mention people who would be interested in the changeset (if any)

The partial prefix may match >1000 revisions, and there isn't a simple way to continue fetching; instead, limiting the prefix to the revision of interest seems to behave just fine.
